### PR TITLE
Feature/new parser/syntax backup

### DIFF
--- a/test_feature/syntax/v3-4.original.peg
+++ b/test_feature/syntax/v3-4.original.peg
@@ -1,0 +1,433 @@
+/**
+ * # Modelica Version 3.4 Syntax
+ *
+ * The following syntactic meta symbols are used (extended BNF):
+ *
+ * [ ]         optional
+ * { }         repeat zero or more times
+ * |           or
+ * "text"      The text is treated as a single token (no whitespace between any characters)
+ * !           When prefixed, indicates that it does not begin with that element
+ * r'regex',   The string prefixed with r is a regular expression and is treated as a single token
+ * `keyword`   Keyword literal is treated as a single token with no word component characters following
+ */
+
+/**
+ * https://specification.modelica.org/maint/3.4/Ch2.html#identifiers-names-and-keywords
+ * #### 2.3.3 Modelica Keywords
+ * The following Modelica keywords are reserved words and may not be used as identifiers, except as listed in section B.1:
+ */
+$KEYWORD =
+   `algorithm`     | `discrete`      | `false`     | `loop`        | `pure`          |
+   `and`           | `each`          | `final`     | `model`       | `record`        |
+   `annotation`    | `else`          | `flow`      | `not`         | `redeclare`     |
+                     `elseif`        | `for`       | `operator`    | `replaceable`   |
+   `block`         | `elsewhen`      | `function`  | `or`          | `return`        |
+   `break`         | `encapsulated`  | `if`        | `outer`       | `stream`        |
+   `class`         | `end`           | `import`    | `output`      | `then`          |
+   `connect`       | `enumeration`   | `impure`    | `package`     | `true`          |
+   `connector`     | `equation`      | `in`        | `parameter`   | `type`          |
+   `constant`      | `expandable`    | `initial`   | `partial`     | `when`          |
+   `constrainedby` | `extends`       | `inner`     | `protected`   | `while`         |
+   `der`           | `external`      | `input`     | `public`      | `within`
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#lexical-conventions
+ * ### B.1 Lexical conventions
+ */
+IDENT = !$KEYWORD NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
+
+Q-IDENT = "'" ( Q-CHAR | S-ESCAPE ) { Q-CHAR | S-ESCAPE | """ } "'"
+
+NONDIGIT = "_" | r'[a-z]' | r'[A-Z]'
+
+STRING = """ { S-CHAR | S-ESCAPE } """
+
+S-CHAR = r'[^"\\]'  // see below
+
+Q-CHAR =
+  NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" | "*" | "+" | "," |
+   "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" | "?" | "@" | "[" | "]" | "^" |
+   "{" | "}" | "|" | "~" | " "
+
+S-ESCAPE =
+   "\'" | "\"" | "\?" | "\\" |
+   "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
+
+DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+UNSIGNED-INTEGER = DIGIT { DIGIT }
+
+UNSIGNED-NUMBER =
+   UNSIGNED-INTEGER [ "." [ UNSIGNED-INTEGER ] ]
+   [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
+
+/**
+ * S-CHAR is any member of the Unicode character set
+ * (http://www.unicode.org; see section 13.2.2 for storing as UTF-8 on files)
+ * except double-quote """, and backslash "\"
+ */
+
+// Modelica uses the same comment syntax as C++ and Java
+// (i.e., // signals the start of a line comment and /**/ ... . */ is a multi-line comment)
+$COMMENT =
+     r"//.*"                   // single-line comment
+   | r"/\*([^*]|\*(?!/))*\*/"  // multi-line comment
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#grammar
+ * ### B.2 Grammar
+ */
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#stored-definition-within
+ * #### B.2.1 Stored Definition - Within
+ */
+stored-definition :
+   [ `within` [ name ] ";" ]
+   { [ `final` ] class-definition ";" }
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#class-definition
+ * #### B.2.2 Class Definition
+ */
+class-definition :
+   [ `encapsulated` ] class-prefixes
+   class-specifier
+
+class-prefixes :
+   [ `partial` ]
+   ( `class` | `model` | [ `operator` ] `record` | `block` | [ `expandable` ] `connector` | `type` |
+   `package` | [ ( `pure` | `impure` ) ] [ `operator` ] `function` | `operator` )
+
+class-specifier :
+   long-class-specifier | short-class-specifier | der-class-specifier
+
+long-class-specifier :
+   IDENT string-comment composition `end` IDENT
+   | `extends` IDENT [ class-modification ] string-comment composition
+   `end` IDENT
+
+short-class-specifier :
+   IDENT "=" base-prefix type-specifier [ array-subscripts ]
+   [ class-modification ] comment
+   | IDENT "=" enumeration "(" ( [enum-list] | ":" ) ")" comment
+
+der-class-specifier :
+   IDENT "=" `der` "(" type-specifier "," IDENT { "," IDENT } ")" comment
+
+base-prefix :
+   [ `input` | `output` ]
+
+enum-list : enumeration-literal { "," enumeration-literal}
+
+enumeration-literal : IDENT comment
+
+composition :
+   element-list
+   { `public` element-list |
+     `protected` element-list |
+     equation-section |
+     algorithm-section
+   }
+   [ `external` [ language-specification ]
+   [ external-function-call ] [ annotation-comment ] ";" ]
+   [ annotation-comment ";" ]
+
+language-specification :
+   STRING
+
+external-function-call :
+   [ component-reference "=" ]
+   IDENT "(" [ expression-list ] ")"
+
+element-list :
+   { element ";" }
+
+element :
+   import-clause |
+   extends-clause |
+   [ `redeclare` ]
+   [ `final` ]
+   [ `inner` ] [ `outer` ]
+   ( ( class-definition | component-clause ) |
+   `replaceable` ( class-definition | component-clause )
+   [ constraining-clause comment ] )
+
+import-clause :
+   `import` ( IDENT "=" name | name ["." ( "*" | "{" import-list "}" ) ] ) comment
+
+import-list :
+   IDENT { "," IDENT }
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#extends
+ * #### B.2.3 Extends
+ */
+extends-clause :
+   `extends` type-specifier [ class-modification ] [ annotation-comment ]
+
+constraining-clause :
+   `constrainedby` type-specifier [ class-modification ]
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#component-clause
+ * #### B.2.4 Component Clause
+ */
+component-clause :
+   type-prefix type-specifier [ array-subscripts ] component-list
+
+type-prefix :
+   [ `flow` | `stream` ]
+   [ `discrete` | `parameter` | `constant` ] [ `input` | `output` ]
+
+component-list :
+   component-declaration { "," component-declaration }
+
+component-declaration :
+   declaration [ condition-attribute ] comment
+
+condition-attribute :
+   `if` expression
+
+declaration :
+   IDENT [ array-subscripts ] [ modification ]
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#modification
+ * #### B.2.5 Modification
+ */
+modification :
+   class-modification [ "=" expression ]
+   | "=" expression
+   | ":=" expression
+
+class-modification :
+   "(" [ argument-list ] ")"
+
+argument-list :
+   argument { "," argument }
+
+argument :
+   element-modification-or-replaceable
+   | element-redeclaration
+
+element-modification-or-replaceable :
+   [ `each` ] [ `final` ] ( element-modification | element-replaceable)
+
+element-modification :
+   name [ modification ] string-comment
+
+element-redeclaration :
+   `redeclare` [ `each` ] [ `final` ]
+   ( ( short-class-definition | component-clause1) | element-replaceable )
+
+element-replaceable :
+   `replaceable` ( short-class-definition | component-clause1 )
+   [ constraining-clause ]
+
+component-clause1 :
+   type-prefix type-specifier component-declaration1
+
+component-declaration1 :
+   declaration comment
+
+short-class-definition :
+   class-prefixes short-class-specifier
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#equations1
+ * #### B.2.6 Equations
+ */
+equation-section :
+   [ `initial` ] `equation` { equation ";" }
+
+algorithm-section :
+   [ `initial` ] `algorithm` { statement ";" }
+
+equation :
+   ( simple-expression "=" expression
+     | if-equation
+     | for-equation
+     | connect-clause
+     | when-equation
+     | component-reference function-call-args )
+   comment
+
+statement :
+   ( component-reference ( ":=" expression | function-call-args )
+     | "(" output-expression-list ")" ":=" component-reference function-call-args
+     | `break`
+     | `return`
+     | if-statement
+     | for-statement
+     | while-statement
+     | when-statement )
+   comment
+
+if-equation :
+   `if` expression `then`
+     { equation ";" }
+   { `elseif` expression `then`
+     { equation ";" }
+   }
+   [ `else`
+     { equation ";" }
+   ]
+   `end` `if`
+
+if-statement :
+   `if` expression `then`
+     { statement ";" }
+   { `elseif` expression `then`
+     { statement ";" }
+   }
+   [ `else`
+     { statement ";" }
+   ]
+   `end` `if`
+
+for-equation :
+   `for` for-indices `loop`
+     { equation ";" }
+   `end` `for`
+
+for-statement :
+   `for` for-indices `loop`
+     { statement ";" }
+   `end` `for`
+
+for-indices :
+   for-index {"," for-index}
+
+for-index :
+   IDENT [ `in` expression ]
+
+while-statement :
+   `while` expression `loop`
+   { statement ";" }
+   `end` `while`
+
+when-equation :
+   `when` expression `then`
+     { equation ";" }
+   { `elsewhen` expression `then`
+     { equation ";" } }
+   `end` `when`
+
+when-statement :
+   `when` expression `then`
+     { statement ";" }
+   { `elsewhen` expression `then`
+     { statement ";" } }
+   `end` `when`
+
+connect-clause :
+   connect "(" component-reference "," component-reference ")"
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#expressions1
+ * #### B.2.7 Expressions
+ */
+expression :
+   simple-expression
+   | `if` expression `then` expression { `elseif` expression `then` expression }
+   `else` expression
+
+simple-expression :
+   logical-expression [ ":" logical-expression [ ":" logical-expression ] ]
+
+logical-expression :
+   logical-term { `or` logical-term }
+
+logical-term :
+   logical-factor { `and` logical-factor }
+
+logical-factor :
+   [ `not` ] relation
+
+relation :
+   arithmetic-expression [ relational-operator arithmetic-expression ]
+
+relational-operator :
+   "<" | "<=" | ">" | ">=" | "==" | "<>"
+
+arithmetic-expression :
+   [ add-operator ] term { add-operator term }
+
+add-operator :
+   "+" | "-" | ".+" | ".-"
+
+term :
+   factor { mul-operator factor }
+
+mul-operator :
+   "*" | "/" | ".*" | "./"
+
+factor :
+   primary [ ("^" | ".^") primary ]
+
+primary :
+   UNSIGNED-NUMBER
+   | STRING
+   | `false`
+   | `true`
+   | (component-reference | `der` | `initial` | `pure` ) function-call-args
+   | component-reference
+   | "(" output-expression-list ")"
+   | "[" expression-list { ";" expression-list } "]"
+   | "{" array-arguments "}"
+   | `end`
+
+type-specifier : ["."] name
+
+name : IDENT { "." IDENT }
+
+component-reference :
+   [ "." ] IDENT [ array-subscripts ] { "." IDENT [ array-subscripts ] }
+
+function-call-args :
+   "(" [ function-arguments ] ")"
+
+function-arguments :
+   expression [ "," function-arguments-non-first | `for` for-indices ]
+   | `function` type-specifier "(" [ named-arguments ] ")" [ "," function-arguments-non-first ]
+   | named-arguments
+
+function-arguments-non-first :
+   function-argument [ "," function-arguments-non-first ]
+   | named-arguments
+
+array-arguments :
+   expression [ "," array-arguments-non-first | `for` for-indices ]
+
+array-arguments-non-first :
+   expression [ "," array-arguments-non-first ]
+
+named-arguments : named-argument [ "," named-arguments ]
+
+named-argument : IDENT "=" function-argument
+
+function-argument :
+   `function` type-specifier "(" [ named-arguments ] ")" | expression
+
+output-expression-list :
+   [ expression ] { "," [ expression ] }
+
+expression-list :
+   expression { "," expression }
+
+array-subscripts :
+   "[" subscript { "," subscript } "]"
+
+subscript :
+   ":" | expression
+
+comment :
+   string-comment [ annotation-comment ]
+
+string-comment :
+   [ STRING { "+" STRING } ]
+
+annotation-comment :
+   `annotation` class-modification

--- a/test_feature/syntax/v3-4.peg
+++ b/test_feature/syntax/v3-4.peg
@@ -1,50 +1,65 @@
 /**
+ * # Modelica Version 3.4 Syntax
+ *
+ * The following syntactic meta symbols are used (extended BNF):
+ *
+ * [ ]         optional
+ * { }         repeat zero or more times
+ * |           or
+ * "text"      The text is treated as a single token (no whitespace between any characters)
+ * !           When prefixed, indicates that it does not begin with that element
+ * r'regex',   The string prefixed with r is a regular expression and is treated as a single token
+ * `keyword`   Keyword literal is treated as a single token with no word component characters following
+ */
+
+/**
  * https://specification.modelica.org/maint/3.4/Ch2.html#identifiers-names-and-keywords
- * ### 2.3.3 Modelica Keywords
+ * #### 2.3.3 Modelica Keywords
  * The following Modelica keywords are reserved words and may not be used as identifiers, except as listed in section B.1:
  */
 $KEYWORD =
-   `algorithm`       | `discrete`      | `false`     | `loop`        | `pure`
-   | `and`           | `each`          | `final`     | `model`       | `record`
-   | `annotation`    | `else`          | `flow`      | `not`         | `redeclare`
-                     | `elseif`        | `for`       | `operator`    | `replaceable`
-   | `block`         | `elsewhen`      | `function`  | `or`          | `return`
-   | `break`         | `encapsulated`  | `if`        | `outer`       | `stream`
-   | `class`         | `end`           | `import`    | `output`      | `then`
-   | `connect`       | `enumeration`   | `impure`    | `package`     | `true`
-   | `connector`     | `equation`      | `in`        | `parameter`   | `type`
-   | `constant`      | `expandable`    | `initial`   | `partial`     | `when`
-   | `constrainedby` | `extends`       | `inner`     | `protected`   | `while`
-   | `der`           | `external`      | `input`     | `public`      | `within`
+   `algorithm`     | `discrete`      | `false`     | `loop`        | `pure`          |
+   `and`           | `each`          | `final`     | `model`       | `record`        |
+   `annotation`    | `else`          | `flow`      | `not`         | `redeclare`     |
+                     `elseif`        | `for`       | `operator`    | `replaceable`   |
+   `block`         | `elsewhen`      | `function`  | `or`          | `return`        |
+   `break`         | `encapsulated`  | `if`        | `outer`       | `stream`        |
+   `class`         | `end`           | `import`    | `output`      | `then`          |
+   `connect`       | `enumeration`   | `impure`    | `package`     | `true`          |
+   `connector`     | `equation`      | `in`        | `parameter`   | `type`          |
+   `constant`      | `expandable`    | `initial`   | `partial`     | `when`          |
+   `constrainedby` | `extends`       | `inner`     | `protected`   | `while`         |
+   `der`           | `external`      | `input`     | `public`      | `within`
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#lexical-conventions
- * ## B.1 Lexical conventions
- * The following syntactic meta symbols are used (extended BNF):
- *
- * [ ] optional
- * { } repeat zero or more times
- * | or
- * "text" The text is treated as a single token (no whitespace between any characters)
- * ~ do not match at current location
+ * ### B.1 Lexical conventions
  */
-
-// IDENT = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 IDENT = !$KEYWORD NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
+
 Q-IDENT = "'" ( Q-CHAR | S-ESCAPE ) { Q-CHAR | S-ESCAPE | """ } "'"
-// NONDIGIT = "_" | letters "a" to "z" | letters "A" to "Z"
+
 NONDIGIT = "_" | r'[a-z]' | r'[A-Z]'
+
 STRING = """ { S-CHAR | S-ESCAPE } """
-// S-CHAR = see below
-S-CHAR = r'[^"\\]'
-Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" | "*" | "+" | "," |
+
+S-CHAR = r'[^"\\]'  // see below
+
+Q-CHAR =
+  NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" | "*" | "+" | "," |
    "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" | "?" | "@" | "[" | "]" | "^" |
    "{" | "}" | "|" | "~" | " "
-S-ESCAPE = "\'" | "\"" | "\?" | "\\" |
+
+S-ESCAPE =
+   "\'" | "\"" | "\?" | "\\" |
    "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
+
 DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
 UNSIGNED-INTEGER = DIGIT { DIGIT }
-UNSIGNED-NUMBER = UNSIGNED-INTEGER [ "." [ UNSIGNED-INTEGER ] ]
+
+UNSIGNED-NUMBER =
+   UNSIGNED-INTEGER [ "." [ UNSIGNED-INTEGER ] ]
    [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
 
 /**
@@ -61,17 +76,20 @@ $COMMENT =
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#grammar
- * ## B.2 Grammar
- * https://specification.modelica.org/maint/3.4/A2.html#stored-definition-within
- * ### B.2.1 Stored Definition - Within
+ * ### B.2 Grammar
  */
-stored-definition:
+
+/**
+ * https://specification.modelica.org/maint/3.4/A2.html#stored-definition-within
+ * #### B.2.1 Stored Definition - Within
+ */
+stored-definition :
    [ `within` [ name ] ";" ]
    { [ `final` ] class-definition ";" }
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#class-definition
- * ### B.2.2 Class Definition
+ * #### B.2.2 Class Definition
  */
 class-definition :
    [ `encapsulated` ] class-prefixes
@@ -125,6 +143,7 @@ external-function-call :
 
 element-list :
    { element ";" }
+
 element :
    import-clause |
    extends-clause |
@@ -133,7 +152,7 @@ element :
    [ `inner` ] [ `outer` ]
    ( ( class-definition | component-clause ) |
    `replaceable` ( class-definition | component-clause )
-   [ constraining-clause  comment ] )
+   [ constraining-clause comment ] )
 
 import-clause :
    `import` ( IDENT "=" name | name ["." ( "*" | "{" import-list "}" ) ] ) comment
@@ -143,7 +162,7 @@ import-list :
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#extends
- * ### B.2.3 Extends
+ * #### B.2.3 Extends
  */
 extends-clause :
    `extends` type-specifier [ class-modification ] [ annotation-comment ]
@@ -153,9 +172,9 @@ constraining-clause :
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#component-clause
- * ### B.2.4 Component Clause
+ * #### B.2.4 Component Clause
  */
-component-clause:
+component-clause :
    type-prefix type-specifier [ array-subscripts ] component-list
 
 type-prefix :
@@ -168,7 +187,7 @@ component-list :
 component-declaration :
    declaration [ condition-attribute ] comment
 
-condition-attribute:
+condition-attribute :
    `if` expression
 
 declaration :
@@ -176,7 +195,7 @@ declaration :
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#modification
- * ### B.2.5 Modification
+ * #### B.2.5 Modification
  */
 modification :
    class-modification [ "=" expression ]
@@ -218,7 +237,7 @@ short-class-definition :
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#equations1
- * ### B.2.6 Equations
+ * #### B.2.6 Equations
  */
 equation-section :
    [ `initial` ] `equation` { equation ";" }
@@ -281,7 +300,7 @@ for-statement :
 for-indices :
    for-index {"," for-index}
 
-for-index:
+for-index :
    IDENT [ `in` expression ]
 
 while-statement :
@@ -308,7 +327,7 @@ connect-clause :
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#expressions1
- * B.2.7 Expressions
+ * #### B.2.7 Expressions
  */
 expression :
    simple-expression
@@ -385,14 +404,14 @@ array-arguments :
 array-arguments-non-first :
    expression [ "," array-arguments-non-first ]
 
-named-arguments: named-argument [ "," named-arguments ]
+named-arguments : named-argument [ "," named-arguments ]
 
-named-argument: IDENT "=" function-argument
+named-argument : IDENT "=" function-argument
 
 function-argument :
    `function` type-specifier "(" [ named-arguments ] ")" | expression
 
-output-expression-list:
+output-expression-list :
    [ expression ] { "," [ expression ] }
 
 expression-list :


### PR DESCRIPTION
In Parsing Expression Grammar (PEG), the first match for an or-concatenated rule is always used.
The order of the or rules needs to be adjusted because the rules may not work correctly if the Modelica standard is used as is.

For verification, the original grammar definition without modification is saved.