### PR TITLE
Feature/new parser/refactor parser

### DIFF
--- a/test_feature/parser.py
+++ b/test_feature/parser.py
@@ -3,18 +3,18 @@ from typing import Any, List
 from typing_extensions import Final
 
 
+# ## Lexical symbols & keywords
 LEXICAL_ASSIGNMENT_OPERATOR: Final[List[str]] = ["=", "|="]
 SYNTAX_ASSIGNMENT_OPERATOR: Final[List[str]] = [":", "|:"]
 NOT_OPERATOR: Final[str] = "!"
 OR_OPERATOR: Final[str] = "|"
 
-# ## Lexical keyword
 KEYWORD_RULE_NAME: Final[str] = "$KEYWORD"
 COMMENT_RULE_NAME: Final[str] = "$COMMENT"
 EOF_RULE_NAME: Final[str] = "$EOF"
 
 
-# # lexical rules
+# ## Lexical rules
 def KEYWORD() -> RegExMatch:
     return RegExMatch("`[a-z]+`")
 
@@ -55,7 +55,7 @@ def SYNTAX_RULE_REFERENCE() -> Any:
     ]
 
 
-# # grammar rule
+# ## Syntax rules
 def grammar() -> Any:
     return (OneOrMore([lexical_rule, syntax_rule]), EOF)
 
@@ -148,7 +148,7 @@ def syntax_primary() -> Any:
     ]
 
 
-# # comment rule
+# ## Comment rule
 def comment() -> Any:
     return [
         RegExMatch(r"//.*"),

--- a/test_feature/parser.py
+++ b/test_feature/parser.py
@@ -23,11 +23,8 @@ def TEXT() -> RegExMatch:
     return RegExMatch(r'"[^"]*"+')
 
 
-def REGEX() -> Any:
-    return [
-        RegExMatch(r"""r'[^'\\]*(?:\\.[^'\\]*)*'"""),
-        RegExMatch(r'''r"[^"\\]*(?:\\.[^"\\]*)*"'''),
-    ]
+def REGEX() -> RegExMatch:
+    return RegExMatch(r"""r'[^'\\]*(?:\\.[^'\\]*)*'""")
 
 
 def LEXICAL_RULE_IDENTIFIER() -> RegExMatch:

--- a/test_feature/syntax/v3-4.original.peg
+++ b/test_feature/syntax/v3-4.original.peg
@@ -71,8 +71,8 @@ UNSIGNED-NUMBER =
 // Modelica uses the same comment syntax as C++ and Java
 // (i.e., // signals the start of a line comment and /**/ ... . */ is a multi-line comment)
 $COMMENT =
-     r"//.*"                   // single-line comment
-   | r"/\*([^*]|\*(?!/))*\*/"  // multi-line comment
+     r'//.*'                   // single-line comment
+   | r'/\*([^*]|\*(?!/))*\*/'  // multi-line comment
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#grammar

--- a/test_feature/syntax/v3-4.peg
+++ b/test_feature/syntax/v3-4.peg
@@ -71,8 +71,8 @@ UNSIGNED-NUMBER =
 // Modelica uses the same comment syntax as C++ and Java
 // (i.e., // signals the start of a line comment and /**/ ... . */ is a multi-line comment)
 $COMMENT =
-     r"//.*"                   // single-line comment
-   | r"/\*([^*]|\*(?!/))*\*/"  // multi-line comment
+     r'//.*'                   // single-line comment
+   | r'/\*([^*]|\*(?!/))*\*/'  // multi-line comment
 
 /**
  * https://specification.modelica.org/maint/3.4/A2.html#grammar

--- a/test_feature/test_1st.py
+++ b/test_feature/test_1st.py
@@ -8,7 +8,7 @@ from .syntax import v3_4
 dialects = [
     "",
     """
-IDENT |= r"\\$\\w*"
+IDENT |= r'\\$\\w*'
     """,
     """
 file: stored-definition $EOF


### PR DESCRIPTION
Restricted the use of only single quote `'` for regular expression literals in grammar definitions.