### PR TITLE
Refactor/syntax module

### DIFF
--- a/modelica_language/__init__.py
+++ b/modelica_language/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ("syntax",)
+
+from . import syntax

--- a/modelica_language/syntax/__init__.py
+++ b/modelica_language/syntax/__init__.py
@@ -1,7 +1,7 @@
-import functools
-import pkg_resources
+__all__ = ("v3_4",)
+
+from pkg_resources import resource_string
 
 
-@functools.lru_cache(1)
 def v3_4() -> str:
-    return pkg_resources.resource_string(__name__, "v3-4.peg").decode("ASCII")
+    return resource_string(__name__, "v3-4.peg").decode("ascii")


### PR DESCRIPTION
- Changed to import `modelica_language.syntax` by default
- Grammar definitions are no longer needed once the parser is generated, so they are uncached.