### PR TITLE
Refactor/convert hyphen

### DIFF
--- a/modelica_language/_parser.py
+++ b/modelica_language/_parser.py
@@ -234,12 +234,6 @@ class GrammarVisitor(PTNodeVisitor):
         self.__ignore_case = ignore_case
         self.__rules = dict(self.__DEFAULT_RULES)
 
-    @property
-    def __skipws(self) -> RegExMatch:
-        skipws = RegExMatch(r"\s*")
-        skipws.compile()
-        return skipws
-
     def visit_KEYWORD(self, node: Any, children: Any) -> Any:
         match = RegExMatch(
             rf"{node.value[1:-1]}(?![0-9_a-zA-Z])",
@@ -263,7 +257,7 @@ class GrammarVisitor(PTNodeVisitor):
 
     def visit_WORD_REFERENCE(self, node: Any, children: Any) -> Any:
         crossref = self.__visit_REFERENCE(node, children)
-        return Sequence(nodes=[self.__skipws, crossref])
+        return Sequence(nodes=[self.skipws, crossref])
 
     visit_SYNTAX_REFERENCE = __visit_REFERENCE
 
@@ -425,6 +419,13 @@ class GrammarVisitor(PTNodeVisitor):
         if root_rule is None:
             raise SemanticError("Root rule not found!")
         return root_rule, comment_rule
+
+    # Utilities
+    @property
+    def skipws(self) -> RegExMatch:
+        skipws = RegExMatch(r"\s*")
+        skipws.compile()
+        return skipws
 
 
 class Parser(ArpeggioParser):

--- a/modelica_language/_parser.py
+++ b/modelica_language/_parser.py
@@ -257,7 +257,7 @@ class GrammarVisitor(PTNodeVisitor):
     visit_SYNTAX_RULE_IDENTIFIER = __visit_IDENTIFIER
 
     def __visit_REFERENCE(self, node: Any, children: Any) -> Any:
-        identifier = self.hyphen2underscore(node.value)
+        (identifier,) = children
         assert "-" not in identifier
         return CrossRef(identifier)
 

--- a/modelica_language/_parser.py
+++ b/modelica_language/_parser.py
@@ -229,8 +229,8 @@ class GrammarVisitor(PTNodeVisitor):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.__root_rule_name = root_rule_name
-        self.__comment_rule_name = comment_rule_name
+        self.__root_rule_name = self.hyphen2underscore(root_rule_name)
+        self.__comment_rule_name = self.hyphen2underscore(comment_rule_name)
         self.__ignore_case = ignore_case
         self.__rules = dict(self.__DEFAULT_RULES)
 
@@ -250,8 +250,16 @@ class GrammarVisitor(PTNodeVisitor):
         match.compile()
         return match
 
+    def __visit_IDENTIFIER(self, node: Any, children: Any) -> Any:
+        return self.hyphen2underscore(node.value)
+
+    visit_LEXICAL_RULE_IDENTIFIER = __visit_IDENTIFIER
+    visit_SYNTAX_RULE_IDENTIFIER = __visit_IDENTIFIER
+
     def __visit_REFERENCE(self, node: Any, children: Any) -> Any:
-        return CrossRef(node.value)
+        identifier = self.hyphen2underscore(node.value)
+        assert "-" not in identifier
+        return CrossRef(identifier)
 
     visit_PART_OF_WORD_REFERENCE = __visit_REFERENCE
 
@@ -320,6 +328,7 @@ class GrammarVisitor(PTNodeVisitor):
 
     def __visit_rule(self, node: Any, children: Any) -> Any:
         rule_name, operator, new_rule = children
+        assert "-" not in rule_name
 
         if operator in {"=", ":"}:
             rule = new_rule
@@ -426,6 +435,10 @@ class GrammarVisitor(PTNodeVisitor):
         skipws = RegExMatch(r"\s*")
         skipws.compile()
         return skipws
+
+    @staticmethod
+    def hyphen2underscore(hyphen: str) -> str:
+        return hyphen.replace("-", "_")
 
 
 class Parser(ArpeggioParser):


### PR DESCRIPTION
In the PEG definition, the only character that can be used to delimit the identifier of a grammar element is `-`.
On the other hand, in parsing, the grammar element should be a valid Python identifier, and `_` should be used to delimit the identifier.

With this in mind, we converted to `-` => `_` at an early stage of parser generation.

Also, in the specification of grammar elements at the time of parser creation, we have made it acceptable to confuse `-` and `_`.