### PR TITLE
Update to `Combine` only if two-or-more elements

### DIFF
--- a/modelica_language/_parser.py
+++ b/modelica_language/_parser.py
@@ -308,7 +308,11 @@ class GrammarVisitor(PTNodeVisitor):
             return Sequence(nodes=[head, *tail])
 
     def visit_lexical_sequence(self, node: Any, children: Any) -> Any:
-        return Combine(nodes=self.__visit_sequence(node, children))
+        head, *tail = children
+        if not tail:
+            return head
+        else:
+            return Combine(nodes=Sequence(nodes=[head, *tail]))
 
     visit_syntax_sequence = __visit_sequence
 


### PR DESCRIPTION
Updated to combine lexical elements when sequence length is greater than 1