### PR TITLE
Stop use group feature (in poetry>=1.2)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -334,7 +334,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "77ff942d08799d35256186f5a2c8bfd333dee1a8e17834a1ac07c49194fbef1a"
+content-hash = "9de9b502714d0a6fb7709fac8b5abfa622ab9eee3286794016120ae89b81a676"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python = "^3.6"
 Arpeggio = ">=1.6"
 typing-extensions = ">=3.7"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.dev-dependencies]
 pyproject-flake8 = "^0.0.1-alpha.2"
 mypy = "^0.910"
 pytest = "^6.2.5"


### PR DESCRIPTION
- In `poetry-core<=1.1`, setting with dev-dependencies must be in `tool.poetry.dev-dependencies`.
- In `poetry-core>1.2`, `tool.poetry.dev-dependencies` will be deprecated, and `tool.poetry.group.dev.dependencies` is recommended.
- `poetry-core>1.2` needs `python>=3.7`, but this project support `python>=3.6` for compatibility

s.t. downgrade as `tool.poetry.dev-dependencies`  instead of `tool.poetry.group.dev.dependencies`