### PR TITLE
Debug/parser peg

### DIFF
--- a/arpeggio-stubs/__init__.pyi
+++ b/arpeggio-stubs/__init__.pyi
@@ -113,6 +113,8 @@ def visit_parse_tree(
 
 class Parser(DebugPrinter):
     ignore_case: bool
+    parser_model: ParsingExpression
+    comments_model: ParsingExpression | None
     def __init__(
         self,
         skipws: bool = ...,

--- a/tests/test_modelica_compliance.py
+++ b/tests/test_modelica_compliance.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Union
 
 import pytest
-from arpeggio import EndOfFile, ParserPython
+from arpeggio import EndOfFile, ParserPython, ParseTreeNode
 from pkg_resources import resource_filename
 
 from modelica_language import ParserPEG
@@ -85,4 +85,6 @@ def test_modelica_parser(
     assert parser.comments_model.root
     assert parser.comments_model.rule_name in ("COMMENT", "CPP_STYLE_COMMENT")
 
-    parser.parse(source_file.read_text(encoding="utf-8-sig"))
+    parseTree = parser.parse(source_file.read_text(encoding="utf-8-sig"))
+
+    assert isinstance(parseTree, ParseTreeNode)

--- a/tests/test_modelica_compliance.py
+++ b/tests/test_modelica_compliance.py
@@ -73,7 +73,16 @@ def test_modelica_parser(
     peg_parser: ParserPEG,
     source_file: Path,
 ) -> None:
-    parser_enum.select_parser(
+    parser = parser_enum.select_parser(
         py_parser,
         peg_parser,
-    ).parse(source_file.read_text(encoding="utf-8-sig"))
+    )
+
+    assert parser.parser_model.root
+    assert parser.parser_model.rule_name == "file"
+
+    assert parser.comments_model is not None
+    assert parser.comments_model.root
+    assert parser.comments_model.rule_name in ("COMMENT", "CPP_STYLE_COMMENT")
+
+    parser.parse(source_file.read_text(encoding="utf-8-sig"))


### PR DESCRIPTION
Fix bug in `modelica_language._parser.ParserPEG`.

When resolve `SyntaxReference`, put `root=True` and `rule_name=peg2py(reference.ruleName)` into resolved parsingExpression.

If forget to put `root=True` into parsingExpression, `ParserPEG.parse()` will not return `arpeggio.ParseTreeNode` and can't continue to `arpeggio.visit_parse_tree`
