### PR TITLE
Rename modelica_language.v3_4:Syntax.{CPP_STYLE_COMMENT => COMMENT}

### DIFF
--- a/modelica_language/v3_4.py
+++ b/modelica_language/v3_4.py
@@ -397,12 +397,10 @@ class Syntax:
     UNSIGNED_NUMBER.__doc__ = f"UNSIGNED_NUMBER = {regexPEG(unsigned_number)}"
 
     @staticmethod
-    def CPP_STYLE_COMMENT() -> RegExMatch:
+    def COMMENT() -> RegExMatch:
         return RegExMatch(cpp_style_comment)
 
-    CPP_STYLE_COMMENT.__doc__ = (
-        f"CPP_STYLE_COMMENT = {regexPEG(cpp_style_comment)}"
-    )
+    COMMENT.__doc__ = f"COMMENT = {regexPEG(cpp_style_comment)}"
 
     # §B.2 Grammar
     # §B.2.1 Stored Definition - Within

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,15 +28,15 @@ def ident_dialect() -> ParsingExpressionLike:
 def file_parser() -> ParserPython:
     return ParserPython(
         file,
-        Syntax.CPP_STYLE_COMMENT,
+        Syntax.COMMENT,
     )
 
 
 @pytest.fixture(scope="module")
 def ident_parser() -> ParserPython:
-    return ParserPython(ident, Syntax.CPP_STYLE_COMMENT)
+    return ParserPython(ident, Syntax.COMMENT)
 
 
 @pytest.fixture(scope="module")
 def ident_dialect_parser() -> ParserPython:
-    return ParserPython(ident_dialect, Syntax.CPP_STYLE_COMMENT)
+    return ParserPython(ident_dialect, Syntax.COMMENT)


### PR DESCRIPTION
rename rule for comment in syntax
