### PR TITLE
Feature/backend

### DIFF
--- a/bootstrap/__main__.py
+++ b/bootstrap/__main__.py
@@ -3,9 +3,7 @@ import sys
 from ast import Module
 from typing import TextIO
 
-from arpeggio import visit_parse_tree
-
-from modelicalang import enable_method_in_parser_python
+from arpeggio import ParserPython, visit_parse_tree
 
 from ._backport import unparse
 from ._peg_syntax import PEGSyntax
@@ -25,7 +23,7 @@ def main() -> None:
     class_name: str = args.class_name
     output: TextIO = args.output
 
-    with enable_method_in_parser_python as ParserPython:
+    with PEGSyntax:
         peg_parser = ParserPython(
             language_def=PEGSyntax.grammar,
             comment_def=PEGSyntax.COMMENT,

--- a/bootstrap/_ast_generator.py
+++ b/bootstrap/_ast_generator.py
@@ -13,7 +13,7 @@ from ast import (
 from ast import List as AstList
 from ast import Load, Module, Name, Return, Store, Subscript
 from ast import Tuple as AstTuple
-from ast import alias, arg, arguments, expr, expr_context, stmt
+from ast import alias, arg, arguments, expr, expr_context, keyword, stmt
 from dataclasses import dataclass, field
 from functools import reduce
 from operator import or_
@@ -22,6 +22,7 @@ from typing import (
     Collection,
     Iterator,
     List,
+    Mapping,
     NewType,
     Optional,
     Sequence,
@@ -148,6 +149,7 @@ def create_module_with_class(
     import_froms: Sequence[Tuple[str, Sequence[str]]],
     class_name: str,
     class_bases: Sequence[str],
+    class_keywords: Mapping[str, expr],
     class_body: Sequence[stmt],
 ) -> Module:
     body: List[stmt] = []
@@ -172,7 +174,10 @@ def create_module_with_class(
         ClassDef(
             name=class_name,
             bases=[create_attribute(class_base) for class_base in class_bases],
-            keywords=[],
+            keywords=[
+                keyword(arg=arg, value=value)
+                for arg, value in class_keywords.items()
+            ],
             body=class_body,
             decorator_list=[],
         ),

--- a/bootstrap/_peg_syntax.py
+++ b/bootstrap/_peg_syntax.py
@@ -2,11 +2,12 @@ from arpeggio import EOF, Not, OneOrMore, RegExMatch
 
 from modelicalang._backend import (
     ParsingExpressionLike,
+    SyntaxMeta,
     returns_parsing_expression,
 )
 
 
-class PEGSyntax:
+class PEGSyntax(metaclass=SyntaxMeta):
     # ## PEG comment rule
     @staticmethod
     @returns_parsing_expression

--- a/bootstrap/_peg_visitor.py
+++ b/bootstrap/_peg_visitor.py
@@ -72,18 +72,7 @@ class ModuleVisitor(PTNodeVisitor):
     ) -> Module:
         return create_module_with_class(
             imports=[],
-            import_froms=[
-                ("typing", ["ClassVar", "Tuple"]),
-                ("arpeggio", ["Optional", "RegExMatch", "ZeroOrMore"]),
-                (
-                    "modelicalang._backend",
-                    [
-                        "ParsingExpressionLike",
-                        "not_start_with_keyword",
-                        "returns_parsing_expression",
-                    ],
-                ),
-            ],
+            import_froms=[("modelicalang._backend", ["*"])],
             class_name=self.class_name,
             class_bases=[],
             class_body=[

--- a/bootstrap/_peg_visitor.py
+++ b/bootstrap/_peg_visitor.py
@@ -75,7 +75,7 @@ class ModuleVisitor(PTNodeVisitor):
             import_froms=[("modelicalang._backend", ["*"])],
             class_name=self.class_name,
             class_bases=[],
-            class_keywords={},
+            class_keywords={"metaclass": create_attribute("SyntaxMeta")},
             class_body=[
                 *self.__class_body(),
             ],

--- a/bootstrap/_peg_visitor.py
+++ b/bootstrap/_peg_visitor.py
@@ -75,6 +75,7 @@ class ModuleVisitor(PTNodeVisitor):
             import_froms=[("modelicalang._backend", ["*"])],
             class_name=self.class_name,
             class_bases=[],
+            class_keywords={},
             class_body=[
                 *self.__class_body(),
             ],

--- a/modelicalang/__init__.py
+++ b/modelicalang/__init__.py
@@ -1,6 +1,5 @@
 __all__ = (
     "ModelicaVersion",
-    "enable_method_in_parser_python",
     "get_file_parser",
     "get_syntax_type",
     "ParsingExpressionLike",
@@ -21,10 +20,7 @@ if TYPE_CHECKING:
     from arpeggio import _ParsingExpressionLike  # noqa: F401
 
 from . import v3_4, v3_5
-from ._backend import (
-    enable_method_in_parser_python,
-    returns_parsing_expression,
-)
+from ._backend import returns_parsing_expression
 
 latest = v3_5
 """
@@ -51,7 +47,7 @@ def get_file_parser(version: Optional[ModelicaVersion] = None) -> ParserPython:
     def file() -> ParsingExpressionLike:
         return syntax_type.stored_definition, EOF
 
-    with enable_method_in_parser_python:
+    with syntax_type:
         return ParserPython(file, syntax_type.COMMENT)
 
 

--- a/modelicalang/__init__.py
+++ b/modelicalang/__init__.py
@@ -1,6 +1,5 @@
 __all__ = (
     "ModelicaVersion",
-    "get_file_parser",
     "get_syntax_type",
     "ParsingExpressionLike",
     "returns_parsing_expression",
@@ -13,7 +12,6 @@ import enum
 from functools import lru_cache
 from typing import TYPE_CHECKING, Dict, Optional, Type, Union
 
-from arpeggio import EOF, ParserPython
 from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
@@ -38,17 +36,6 @@ _AnySyntaxType = Union[Type[v3_4.Syntax], Type[v3_5.Syntax]]
 class ModelicaVersion(enum.Enum):
     v3_4 = (3, 4)
     v3_5 = latest = (3, 5)
-
-
-def get_file_parser(version: Optional[ModelicaVersion] = None) -> ParserPython:
-    syntax_type = get_syntax_type(version)
-
-    @returns_parsing_expression
-    def file() -> ParsingExpressionLike:
-        return syntax_type.stored_definition, EOF
-
-    with syntax_type:
-        return ParserPython(file, syntax_type.COMMENT)
 
 
 @lru_cache(1)

--- a/modelicalang/_backend.py
+++ b/modelicalang/_backend.py
@@ -1,8 +1,11 @@
 __all__ = (
     "ClassVar",
+    "Optional",
     "ParsingExpression",
     "ParsingExpressionLike",
+    "RegExMatch",
     "Tuple",
+    "ZeroOrMore",
     "enable_method_in_parser_python",
     "not_start_with_keyword",
     "returns_parsing_expression",
@@ -13,19 +16,18 @@ import enum
 import types
 from functools import wraps
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
+from typing import Optional as NoneOr
+from typing import Tuple, Type, TypeVar, cast
 
-from arpeggio import Not, ParserPython, ParsingExpression, RegExMatch
+from arpeggio import (
+    Not,
+    Optional,
+    ParserPython,
+    ParsingExpression,
+    RegExMatch,
+    ZeroOrMore,
+)
 from typing_extensions import ParamSpec, Protocol
 
 if TYPE_CHECKING:
@@ -64,10 +66,10 @@ class EnableMethodInParserPython(enum.Enum):
 
     def __exit__(
         self,
-        typ: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> Optional[bool]:
+        typ: NoneOr[Type[BaseException]],
+        value: NoneOr[BaseException],
+        traceback: NoneOr[TracebackType],
+    ) -> NoneOr[bool]:
         builtins.isinstance = _isinstance__builtins
         return None
 

--- a/modelicalang/_backend.py
+++ b/modelicalang/_backend.py
@@ -11,7 +11,6 @@ __all__ = (
 )
 
 import builtins
-import enum
 import types
 from functools import wraps
 from types import TracebackType
@@ -38,46 +37,15 @@ P = ParamSpec("P")
 T = TypeVar("T")
 T_keywords = TypeVar("T_keywords", bound="SupportsKeywords")
 
-_isinstance__builtins = builtins.isinstance
-
-
-def _isinstance__callable_as_function(obj: Any, class_or_tuple: Any) -> bool:
-    if class_or_tuple is types.FunctionType:  # noqa: E721
-        return _isinstance__builtins(obj, Callable)  # type: ignore
-    else:
-        return _isinstance__builtins(obj, class_or_tuple)
-
-
-class EnableMethodInParserPython(enum.Enum):
-    instance = enum.auto()
-
-    def __call__(self, f: Callable[P, T]) -> Callable[P, T]:
-        @wraps(f)
-        def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-            with self:
-                return f(*args, **kwargs)
-
-        return wrapped
-
-    def __enter__(self) -> Type[ParserPython]:
-        builtins.isinstance = _isinstance__callable_as_function
-        return ParserPython
-
-    def __exit__(
-        self,
-        typ: NoneOr[Type[BaseException]],
-        value: NoneOr[BaseException],
-        traceback: NoneOr[TracebackType],
-    ) -> NoneOr[bool]:
-        builtins.isinstance = _isinstance__builtins
-        return None
-
-
-enable_method_in_parser_python = EnableMethodInParserPython.instance
-
 
 class SupportsKeywords(Protocol):
     _keywords_: ClassVar[Tuple[str, ...]]
+
+
+def returns_parsing_expression(
+    f: Callable[P, ParsingExpressionLike]
+) -> Callable[P, ParsingExpression]:
+    return cast(Callable[P, ParsingExpression], f)
 
 
 def not_start_with_keyword(
@@ -98,11 +66,26 @@ def not_start_with_keyword(
     return wrapped
 
 
-def returns_parsing_expression(
-    f: Callable[P, ParsingExpressionLike]
-) -> Callable[P, ParsingExpression]:
-    return cast(Callable[P, ParsingExpression], f)
+_isinstance__builtins = builtins.isinstance
+
+
+def _isinstance__callable_as_function(obj: Any, class_or_tuple: Any) -> bool:
+    if class_or_tuple is types.FunctionType:  # noqa: E721
+        return _isinstance__builtins(obj, Callable)  # type: ignore
+    else:
+        return _isinstance__builtins(obj, class_or_tuple)
 
 
 class SyntaxMeta(type):
-    ...
+    def __enter__(cls) -> Type[ParserPython]:
+        builtins.isinstance = _isinstance__callable_as_function
+        return ParserPython
+
+    def __exit__(
+        cls,
+        typ: NoneOr[Type[BaseException]],
+        value: NoneOr[BaseException],
+        traceback: NoneOr[TracebackType],
+    ) -> NoneOr[bool]:
+        builtins.isinstance = _isinstance__builtins
+        return None

--- a/modelicalang/_backend.py
+++ b/modelicalang/_backend.py
@@ -1,12 +1,10 @@
 __all__ = (
     "ClassVar",
     "Optional",
-    "ParsingExpression",
     "ParsingExpressionLike",
     "RegExMatch",
     "Tuple",
     "ZeroOrMore",
-    "enable_method_in_parser_python",
     "not_start_with_keyword",
     "returns_parsing_expression",
 )

--- a/modelicalang/_backend.py
+++ b/modelicalang/_backend.py
@@ -3,6 +3,7 @@ __all__ = (
     "Optional",
     "ParsingExpressionLike",
     "RegExMatch",
+    "SyntaxMeta",
     "Tuple",
     "ZeroOrMore",
     "not_start_with_keyword",
@@ -101,3 +102,7 @@ def returns_parsing_expression(
     f: Callable[P, ParsingExpressionLike]
 ) -> Callable[P, ParsingExpression]:
     return cast(Callable[P, ParsingExpression], f)
+
+
+class SyntaxMeta(type):
+    ...

--- a/modelicalang/_backend.py
+++ b/modelicalang/_backend.py
@@ -1,6 +1,8 @@
 __all__ = (
+    "ClassVar",
     "ParsingExpression",
     "ParsingExpressionLike",
+    "Tuple",
     "enable_method_in_parser_python",
     "not_start_with_keyword",
     "returns_parsing_expression",

--- a/modelicalang/v3_4.py
+++ b/modelicalang/v3_4.py
@@ -1,12 +1,4 @@
-from typing import ClassVar, Tuple
-
-from arpeggio import Optional, RegExMatch, ZeroOrMore
-
-from modelicalang._backend import (
-    ParsingExpressionLike,
-    not_start_with_keyword,
-    returns_parsing_expression,
-)
+from modelicalang._backend import *
 
 
 class Syntax:

--- a/modelicalang/v3_4.py
+++ b/modelicalang/v3_4.py
@@ -1,7 +1,7 @@
 from modelicalang._backend import *
 
 
-class Syntax:
+class Syntax(metaclass=SyntaxMeta):
     _keywords_: ClassVar[Tuple[str, ...]] = (
         "algorithm",
         "and",

--- a/modelicalang/v3_5.py
+++ b/modelicalang/v3_5.py
@@ -1,12 +1,4 @@
-from typing import ClassVar, Tuple
-
-from arpeggio import Optional, RegExMatch, ZeroOrMore
-
-from modelicalang._backend import (
-    ParsingExpressionLike,
-    not_start_with_keyword,
-    returns_parsing_expression,
-)
+from modelicalang._backend import *
 
 
 class Syntax:

--- a/modelicalang/v3_5.py
+++ b/modelicalang/v3_5.py
@@ -1,7 +1,7 @@
 from modelicalang._backend import *
 
 
-class Syntax:
+class Syntax(metaclass=SyntaxMeta):
     _keywords_: ClassVar[Tuple[str, ...]] = (
         "algorithm",
         "and",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ exclude_lines = [
 [tool.flake8]
 exclude = ".venv"
 per-file-ignores = [
-    "modelicalang/v?_?.py:E501"
+    "modelicalang/v?_?.py:E501,F403,F405"
 ]
 
 [tool.isort]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,6 @@ from arpeggio import EOF, Not, ParserPython, RegExMatch
 from modelicalang import (
     ModelicaVersion,
     ParsingExpressionLike,
-    enable_method_in_parser_python,
     get_syntax_type,
     returns_parsing_expression,
     v3_5,
@@ -28,7 +27,6 @@ class TargetLanguageDef(enum.Flag):
     UNSIGNED_REAL = enum.auto()
 
     @lru_cache(None)
-    @enable_method_in_parser_python
     def get_parser(
         self, version: Optional[ModelicaVersion] = None
     ) -> ParserPython:
@@ -71,7 +69,8 @@ class TargetLanguageDef(enum.Flag):
                     )
             raise NotImplementedError()
 
-        return ParserPython(file, Syntax.COMMENT)
+        with Syntax:
+            return ParserPython(file, Syntax.COMMENT)
 
 
 class _DialectMixin:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,19 @@ from modelicalang import (
 )
 
 
+def get_stored_definition_parser(
+    version: Optional[ModelicaVersion] = None,
+) -> ParserPython:
+    syntax_type = get_syntax_type(version)
+
+    @returns_parsing_expression
+    def file() -> ParsingExpressionLike:
+        return syntax_type.stored_definition, EOF
+
+    with syntax_type:
+        return ParserPython(file, syntax_type.COMMENT)
+
+
 class TargetLanguageDef(enum.Flag):
     NULL = 0
     IDENT = enum.auto()

--- a/tests/test_modelica_compliance.py
+++ b/tests/test_modelica_compliance.py
@@ -4,7 +4,9 @@ import pytest
 from arpeggio import ParseTreeNode
 from pkg_resources import resource_filename
 
-from modelicalang import ModelicaVersion, get_file_parser
+from modelicalang import ModelicaVersion
+
+from . import get_stored_definition_parser
 
 SOURCE_DIRECTORY = Path(
     resource_filename(__name__, "Modelica-Compliance/ModelicaCompliance/")
@@ -25,7 +27,7 @@ def test_modelica_parser(
     source_file: Path,
     version: ModelicaVersion,
 ) -> None:
-    parseTree = get_file_parser(version).parse(
+    parseTree = get_stored_definition_parser(version).parse(
         source_file.read_text(encoding="utf-8-sig")
     )
     assert isinstance(parseTree, ParseTreeNode)


### PR DESCRIPTION
- Implement `modelicalang._backend.SyntaxMeta`
- Deprecate `modelicalang._backend.enable_method_in_parser_python`
